### PR TITLE
fix: OpenSSL 3.0.Y compatibility fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 
 CXXFLAGS ?= -Wall -pedantic -Wno-long-long -O2
 CXXFLAGS += -std=c++11
+CXXFLAGS+= -DOPENSSL_API_COMPAT=0x30000000L
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man


### PR DESCRIPTION
add CXXFLAGS to allow git-crypt to build on ubuntu-22.04 

See: AGWA/git-crypt#232